### PR TITLE
Add comprehensive documentation for core Fortran files.

### DIFF
--- a/Build_Hamiltonian.md
+++ b/Build_Hamiltonian.md
@@ -1,0 +1,106 @@
+# Documentation for Build_Hamiltonian.F90
+
+## Overview
+
+`Build_Hamiltonian.F90` is responsible for constructing the total Hamiltonian matrix (`Htot`) of the system being simulated. It achieves this by calling various specialized subroutines based on the chosen material model (`MatType`). These subroutines define the on-site energies, hopping terms, spin-orbit coupling, Zeeman effects, and superconducting pairing terms for different types of materials, including topological insulators (TI), topological crystalline insulators (TCI), and s-wave superconductors.
+
+The main subroutine, `Build_Hamiltonian`, first calls a model-specific routine (e.g., `BuildTICells`, `BuildLiangTCICells`) to set up the basic Hamiltonian blocks for the chosen material. It then assembles the full `Htot` matrix by arranging these blocks and incorporating terms for interactions between layers and superconducting pairing potentials (Bogoliubov-de Gennes framework).
+
+## Key Components
+
+*   **SUBROUTINE `Build_Hamiltonian`**:
+    *   The primary subroutine in this file.
+    *   It selects the appropriate material model based on `MatType`.
+    *   Calls helper subroutines to build unit cell Hamiltonians (`AATI`, `AASC`) and hopping matrices (`HopZTI`, `HopZSC`, `HopZZTI`).
+    *   Constructs the full `Htot` matrix by arranging these components, considering different properties for TI and SC layers and the interface between them.
+    *   Adds attractive Hubbard-type interactions for the Bogoliubov-de Gennes (BdG) off-diagonal blocks, incorporating the order parameter `DeltaMat`.
+
+*   **SUBROUTINE `BuildLiangTCICells`**:
+    *   Constructs Hamiltonian components for a Liang Fu Topological Crystalline Insulator (TCI) model.
+    *   Sets up on-site terms (`HOnSite`), spin-orbit coupling (`HSOC`), Zeeman terms (`HZeeman`), and hopping terms (`HHop`, `HHopz`).
+    *   Builds the TI part of the BdG Hamiltonian, including both electron (`AATI(1:12,1:12)`, `HopZTI(1:12,1:12)`) and hole (`AATI(13:24,13:24)`, `HopZTI(13:24,13:24)`) components.
+    *   Calls `BuildTCIHopping` to get k-dependent hopping matrices.
+
+*   **SUBROUTINE `BuildTCIHopping(kxval, kyval)`**:
+    *   Calculates k-dependent nearest-neighbor (`HNN`, `HNNz`) and next-nearest-neighbor (`HNNN`, `HNNNz`) hopping matrices for TCI models.
+    *   These are then combined with coefficients (`LFt11`, `LFt12`, etc.) to form `HHop` and `HHopz`.
+    *   **Input**: `kxval`, `kyval` (k-space coordinates).
+
+*   **SUBROUTINE `BuildChenTCICells`**:
+    *   Constructs Hamiltonian components for Chen's TCI model (assumes `Norb=8`).
+    *   Sets up on-site terms and Zeeman terms for the TI part.
+    *   Calculates z-direction hopping (`HopZTI`) and next-nearest-neighbor z-hopping (`HopZZTI`).
+    *   Includes both electron and hole components for the BdG Hamiltonian.
+
+*   **SUBROUTINE `BuildTICells`**:
+    *   Constructs Hamiltonian components for a model Topological Insulator (assumes `Norb=8`).
+    *   Includes on-site terms (Dirac mass `MM`, k-dependent terms), Zeeman terms, and z-direction hopping.
+    *   Forms both electron and hole parts of the BdG Hamiltonian.
+
+*   **SUBROUTINE `BuildBiSeCells`**:
+    *   Constructs Hamiltonian components specific to Bi2Se3 (assumes `Norb=8`).
+    *   Uses material-specific parameters (e.g., `mpA1`, `mpA2`, `mpC`, `mpMTI`).
+    *   Sets up on-site terms, Zeeman terms, and z-direction hopping.
+    *   Includes both electron and hole components for the BdG Hamiltonian.
+
+*   **SUBROUTINE `BuildSCCells`**:
+    *   Constructs Hamiltonian components for a model s-wave superconductor (assumes `Norb=8`).
+    *   Sets up on-site terms (`AASC`) and z-direction hopping (`HopZSC`).
+    *   Can optionally include Zeeman terms in the SC part if `fullZeeman == 1`.
+    *   Forms both electron and hole parts of the BdG Hamiltonian.
+    *   Defines `HopZSCTI` for hopping between SC and TI layers.
+
+## Important Variables/Constants
+
+*   **`Htot`**: The total Hamiltonian matrix for the system at a given (Kx, Ky). This is the main output of the `Build_Hamiltonian` subroutine.
+*   **`MatType`**: Integer flag selecting the material model (0: Model TI, 1: Liang Fu TCI, 2: Chen TCI, else: Bi2Se3).
+*   **`MM`**: Dirac mass, used in `BuildTICells`.
+*   **`AATI`, `HopZTI`, `HopZZTI`**: Matrices representing the on-site Hamiltonian, z-direction nearest-neighbor hopping, and z-direction next-nearest-neighbor hopping for the TI part, respectively. These are populated by the material-specific cell-building subroutines.
+*   **`AASC`, `HopZSC`**: Matrices representing the on-site Hamiltonian and z-direction hopping for the SC part, populated by `BuildSCCells`.
+*   **`HopZSCTI`**: Hopping matrix between SC and TI layers.
+*   **`Npz`, `NpzSC`, `Norb`**: System dimensions (total z-layers, SC z-layers, number of orbitals).
+*   **`Kx`, `Ky`**: Current k-space coordinates, used by cell-building subroutines to compute k-dependent terms.
+*   **`muTI`, `muSC`**: Chemical potentials for TI and SC regions.
+*   **`UIntTI`, `UIntSC`**: Mean-field interaction strengths.
+*   **`DeltaMat`, `DeltaAS`, `DeltaBS`**: Order parameter matrices/arrays, used to add pairing terms to `Htot`.
+*   **`gDAS`, `gDBS`**: Gamma matrices for s-wave pairing.
+*   **`HOnSite`, `HSOC`, `HZeeman`, `HHop`, `HHopz`**: Component matrices used within `BuildLiangTCICells` and `BuildTCIHopping`.
+*   Tight-binding parameters (e.g., `LFm`, `LFt11`, `CFm`, `CFt1`) and Bi2Se3 specific parameters (e.g., `mpA1`, `mpMTI`).
+*   Gamma matrices (`g0`, `g1`, `g2`, `g3`, `id`, `gMx`, `gMy`, `gMz`) and TCI specific matrices (`SigZ0`, `SigXX`, etc.) are used from `NEGF_Module`.
+
+## Usage Examples
+
+The `Build_Hamiltonian` subroutine is called within the main loop of `NEGF_Main.F90` for each (Kx, Ky) point before the order parameter is calculated.
+
+```fortran
+! In NEGF_Main.F90
+! ...
+DO xx = 1, NpKx
+    DO yy = 1, NpKy
+        ! ... (set Kx, Ky, initial DeltaMat, etc.)
+        DO WHILE ((ite <= iteTot) .AND. (abs(AmtChange)>Accuracy))
+            ite = ite+1
+            CALL Build_Hamiltonian ! Constructs Htot based on current Kx, Ky, DeltaMat
+            CALL Calculate_OP      ! Uses Htot
+        ENDDO
+        ! ...
+    ENDDO
+ENDDO
+! ...
+```
+The choice of `MatType` (read from input) determines which internal path `Build_Hamiltonian` takes:
+*   If `MatType == 0`, `BuildTICells` is called.
+*   If `MatType == 1`, `BuildLiangTCICells` (which calls `BuildTCIHopping`) is called.
+*   And so on for other `MatType` values.
+
+## Dependencies and Interactions
+
+*   **`NEGF_Module` (`USE NEGF_variables`)**: This file heavily relies on `NEGF_Module` for almost all its variables, constants, matrix dimensions, and predefined matrices (like gamma matrices).
+*   **Called by**: `NEGF_Main.F90` (specifically, the `NEGF_main` program).
+*   **Input Data**:
+    *   `Kx`, `Ky` (from `NEGF_Main`).
+    *   `MatType`, `MM`, `muTI`, `muSC`, `UIntTI`, `UIntSC`, `DeltaMat`, `DeltaAS`, `DeltaBS`, `Npz`, `NpzSC`, `Norb`, `a0`, `Mx`, `My`, `Mz`, `fullZeeman`, tight-binding parameters (all from `NEGF_Module`, ultimately from input or defaults).
+*   **Output Data**:
+    *   Modifies `Htot` (in `NEGF_Module`), which is then used by `Calculate_OP.F90`.
+    *   Modifies helper matrices like `AATI`, `HopZTI`, `AASC`, `HopZSC` (in `NEGF_Module`).
+*   The various `Build...Cells` subroutines are internal to this file and call each other as needed (e.g., `BuildLiangTCICells` calls `BuildTCIHopping`).

--- a/Calculate_OP.md
+++ b/Calculate_OP.md
@@ -1,0 +1,84 @@
+# Documentation for Calculate_OP.F90
+
+## Overview
+
+`Calculate_OP.F90` contains subroutines crucial for the self-consistent calculation of the superconducting order parameter and for computing final physical quantities once convergence is achieved. The primary subroutine, `Calculate_OP`, determines the order parameter matrix (`DeltaMat`) by summing over contributions from eigenvectors and eigenvalues of the Hamiltonian. It also calculates the change in the order parameter (`AmtChange`) from the previous iteration, which is used by the main program to check for self-consistency. The second subroutine, `CalculateFinal`, is called after the self-consistency loop to compute observable quantities like the Local Density of States (LDOS), band structure, and ground state energy.
+
+## Key Components
+
+*   **SUBROUTINE `Calculate_OP`**:
+    *   Resets order parameter arrays (`DeltaAS`, `DeltaBS`, `DeltaMat`, etc.) for the current (xx, yy) k-point.
+    *   Calls `get_evalsevecs` (an external MKL routine, presumably) to diagonalize the total Hamiltonian `Htot` (provided as `eigvecs` input, which gets overwritten) and obtain its eigenvalues (`eigvals`) and eigenvectors (`eigvecs`).
+    *   Calculates the order parameter matrix `DeltaMat(xx,yy,zz,jj,kk)` by summing over the positive energy eigenstates, using the formula:
+        `DeltaMat -= conjg(eigvecs(hole_idx, E_idx)) * eigvecs(particle_idx, E_idx) * tanh(eigvals(E_idx)/(2*kB*T0))`
+    *   Derives various components of the order parameter (`DeltaAS`, `DeltaBS`, `DeltaABS`, and their spin-polarized variants like `DeltaAPUp`, `DeltaAPDn`) from `DeltaMat` using predefined pairing gamma matrices (`gDAS`, `gDBS`, etc.).
+    *   If `ite >= 10`, calculates `AmtChange` (maximum absolute difference) and `RMSChange` (root mean square difference) between the current `DeltaMat` and `DeltaMatOld` (from the previous iteration) to quantify convergence.
+    *   Updates `DeltaMatOld` with the current `DeltaMat` for the next iteration.
+
+*   **SUBROUTINE `CalculateFinal`**:
+    *   Calculates spin-resolved and orbital-resolved Local Density of States (LDOS). For each (xx, yy, zz) point and energy `Eaxis(ee)`:
+        `LDOS(xx,yy,zz,ee) += exp(-1e3*(Eaxis(ee)-eigvals(ii))^2) * real(conjg(PsiKet(kk))*PsiKet(ll)*id(kk,ll))`
+        Similar expressions are used for `LDOSMx`, `LDOSMy`, `LDOSMz` (spin-projected LDOS) and `LDOSPx`, `LDOSPy`, `LDOSPz` (orbital-projected LDOS), using `gMx`, `gMy`, `gMz`, `gPx`, `gPy`, `gPz` matrices respectively. `PsiKet` here represents the particle part of an eigenvector.
+    *   Stores the lowest few positive energy eigenvalues (`eigvals(NN/2+1:NN/2+5)`) into `BStruc(xx,yy,1:5)` to represent the band structure.
+    *   Calculates the ground state energy `EGnd(xx,yy)` by summing negative energy eigenvalues and subtracting chemical potential contributions.
+    *   Calculates `EGnd0` (zeroth order ground state energy before Mean-Field Theory subtraction).
+    *   Subtracts Mean-Field Theory (MFT) components related to the calculated order parameters (`DeltaAS`, `DeltaBS`, etc.) from `EGnd(xx,yy)` to get the final ground state energy per layer.
+
+## Important Variables/Constants
+
+*   **`DeltaMat(xx,yy,zz,jj,kk)`**: The primary calculated quantity in `Calculate_OP`. It's the matrix form of the superconducting order parameter for a given k-point (xx,yy) and layer (zz).
+*   **`DeltaAS`, `DeltaBS`, `DeltaABS`, `DeltaAPUp`, etc.**: Various projections of the order parameter, derived from `DeltaMat`.
+*   **`DeltaMatOld(zz,ii,jj)`**: Stores `DeltaMat` from the previous iteration to calculate `AmtChange`.
+*   **`eigvecs`**: Input: `Htot`. Output: Eigenvectors of `Htot`. (Overwritten by `get_evalsevecs`)
+*   **`eigvals`**: Eigenvalues of `Htot`.
+*   **`AmtChange`, `RMSChange`**: Measures of convergence for the order parameter.
+*   **`Htot`**: The total Hamiltonian matrix (input to `get_evalsevecs` via `eigvecs`).
+*   **`NN`**: Total size of the Hamiltonian matrix (`Npz * Norb`).
+*   **`Norb`**: Number of orbitals.
+*   **`Npz`**: Number of layers in z-direction.
+*   **`xx`, `yy`**: Indices for the current k-point.
+*   **`kB`, `T0`**: Boltzmann constant and temperature, used in the `tanh` factor.
+*   **`LDOS`, `LDOSMx`, `LDOSMy`, `LDOSMz`, `LDOSPx`, `LDOSPy`, `LDOSPz`**: Arrays to store calculated Local Density of States and its projections.
+*   **`Eaxis`, `NpE`**: Array of energy points and number of energy points for LDOS calculation.
+*   **`BStruc`**: Array to store band structure information (lowest positive eigenvalues).
+*   **`EGnd`, `EGnd0`**: Arrays for ground state energy.
+*   **`muTI`, `muSC`**: Chemical potentials for TI and SC.
+*   **`UIntTI`, `UIntSC`**: Mean-field interaction strengths for MFT subtraction from `EGnd`.
+*   Pairing gamma matrices (`gDAS`, `gDBS`, `gDABS`, `gDAPUp`, etc.) and projection gamma matrices (`gMx`, `gMy`, `gMz`, `gPx`, `gPy`, `gPz`, `id`) are used from `NEGF_Module`.
+
+## Usage Examples
+
+### `Calculate_OP`
+This subroutine is called inside the self-consistency loop in `NEGF_Main.F90`:
+```fortran
+! In NEGF_Main.F90
+! ...
+DO WHILE ((ite <= iteTot) .AND. (abs(AmtChange)>Accuracy))
+    ite = ite+1
+    CALL Build_Hamiltonian
+    CALL Calculate_OP  ! Calculates DeltaMat, AmtChange using Htot
+ENDDO
+! ...
+```
+
+### `CalculateFinal`
+This subroutine is called after the self-consistency loop in `NEGF_Main.F90` for each k-point that the current MPI process is responsible for:
+```fortran
+! In NEGF_Main.F90
+! ...
+! After the DO WHILE loop for self-consistency:
+CALL CalculateFinal ! Calculates LDOS, BStruc, EGnd using converged eigenvectors/values
+! ...
+```
+
+## Dependencies and Interactions
+
+*   **`NEGF_Module` (`USE NEGF_variables`)**: This file heavily relies on `NEGF_Module` for most of its input variables (like `xx`, `yy`, `Htot` via `eigvecs`, `kB`, `T0`, `Norb`, `NN`, `Npz`, various gamma matrices, `Eaxis`, `NpE`, `muTI`, `muSC`, `UIntTI`, `UIntSC`) and for storing its results (`DeltaMat`, `DeltaAS`, etc., `AmtChange`, `LDOS` arrays, `BStruc`, `EGnd`).
+*   **`get_evalsevecs` (External Subroutine)**: This is a crucial dependency, presumably an MKL (Math Kernel Library) routine or a similar library function, used for eigenvalue decomposition of the Hamiltonian `Htot`. It takes `Htot` (via `eigvecs` which is dimensioned `NN x NN`) and returns `eigvals` (dimension `NN`) and `eigvecs` (overwritten with eigenvectors as columns).
+*   **Called by**: `NEGF_Main.F90`.
+*   **Input Data**:
+    *   For `Calculate_OP`: `Htot` (passed as `eigvecs` which is then overwritten), `xx`, `yy`, `Norb`, `NN`, `Npz`, `kB`, `T0`, `ite`, `DeltaMatOld`, various gamma matrices from `NEGF_Module`.
+    *   For `CalculateFinal`: Converged `eigvecs` and `eigvals`, `xx`, `yy`, `Norb`, `NN`, `Npz`, `Eaxis`, `NpE`, `muTI`, `muSC`, `UIntTI`, `UIntSC`, various gamma matrices from `NEGF_Module`.
+*   **Output Data**:
+    *   `Calculate_OP` modifies: `DeltaMat`, `DeltaAS`, `DeltaBS`, etc., `AmtChange`, `RMSChange`, `DeltaMatOld` (all in `NEGF_Module`). It also overwrites the input `eigvecs` with eigenvectors and fills `eigvals`.
+    *   `CalculateFinal` modifies: `LDOS` arrays, `BStruc`, `EGnd`, `EGnd0` (all in `NEGF_Module`).

--- a/NEGF_Main.md
+++ b/NEGF_Main.md
@@ -1,0 +1,64 @@
+# Documentation for NEGF_Main.F90
+
+## Overview
+
+`NEGF_Main.F90` serves as the main driver program for the Non-Equilibrium Green's Function (NEGF) simulation. It orchestrates the overall workflow, which includes:
+1.  Reading input parameters and allocating necessary data structures.
+2.  Broadcasting initial data to all processes if running in an MPI (Message Passing Interface) environment.
+3.  Iteratively calculating physical quantities (like the order parameter) for different points in k-space. This involves:
+    *   Setting initial conditions for the order parameter.
+    *   Entering a self-consistency loop where the Hamiltonian is built and the order parameter is recalculated until convergence is achieved or the maximum number of iterations is reached.
+4.  Calculating final results after the self-consistency loop.
+5.  Gathering results from all MPI processes (if applicable).
+6.  Dumping the calculated data to output files.
+7.  Finalizing the MPI environment.
+
+The program is designed to simulate properties of materials, particularly topological insulators and superconductors, by solving the NEGF equations self-consistently.
+
+## Key Components
+
+*   **PROGRAM `NEGF_main`**:
+    *   The main program unit. It controls the entire execution flow as described in the Overview.
+
+## Important Variables/Constants
+
+*   **`xx`, `yy`**: Loop counters for iterating over k-space points (Kx, Ky).
+*   **`Kx`, `Ky`**: Current k-space coordinates (momentum components).
+*   **`KxAxis`, `KyAxis`**: Arrays holding the discrete values for Kx and Ky.
+*   **`NpKx`, `NpKy`**: Number of points along the Kx and Ky axes in k-space.
+*   **`NpzSC`**: Number of layers corresponding to the superconducting material.
+*   **`DeltaSC`**: Initial value for the s-wave order parameter in the superconductor.
+*   **`DeltaAS`, `DeltaBS`**: Arrays holding the A-site and B-site components of the order parameter for each k-point and layer.
+*   **`DeltaMat`**: A matrix representing the full pairing potential for each (Kx, Ky, z) point.
+*   **`ite`**: Current iteration number in the self-consistency loop.
+*   **`iteTot`**: Maximum number of iterations allowed for the self-consistency loop.
+*   **`AmtChange`**: The magnitude of change in the order parameter between successive iterations. Used to check for convergence.
+*   **`Accuracy`**: The desired precision for `AmtChange` to consider the calculation converged.
+*   **`EGnd`, `EGnd0`**: Arrays to store the ground state energy.
+*   **`mpisize`, `mpirank`, `mpiroot`**: MPI-related variables for parallel processing (number of processes, rank of current process, rank of the root process).
+
+## Usage Examples
+
+`NEGF_Main.F90` is compiled into an executable. It is typically run from the command line. The specifics of running the program (e.g., command-line arguments for input files or parameters) would depend on how `Read_In_Allocate` is implemented.
+
+Example (conceptual):
+```bash
+./negf_solver input_parameters.txt
+```
+The program then performs the calculations and produces output files as specified in the `DumpData` subroutine.
+
+## Dependencies and Interactions
+
+`NEGF_Main.F90` depends on several other modules and subroutines:
+
+*   **`NEGF_Module` (`USE NEGF_variables`)**: This module provides definitions for many variables and constants used in `NEGF_main`, including physical constants, material parameters, k-space grid details, and MPI variables.
+*   **`Read_In_Allocate`**: A subroutine (presumably in a separate file) responsible for reading input parameters and allocating memory for arrays.
+*   **`BroadcastDataMPI`**: A subroutine (likely in `MPI_routines.F90`) to broadcast initial data from the root MPI process to all other processes.
+*   **`Build_Hamiltonian`**: A subroutine (in `Build_Hamiltonian.F90`) that constructs the total Hamiltonian `Htot` for the current `Kx`, `Ky`, and `z` values.
+*   **`Calculate_OP`**: A subroutine (in `Calculate_OP.F90`) that calculates the order parameter (`DeltaMat`, `DeltaAS`, `DeltaBS`) based on the current Hamiltonian. It also updates `AmtChange`.
+*   **`CalculateFinal`**: A subroutine (in `Calculate_OP.F90`) called after the self-consistency loop to compute final quantities like Local Density of States (LDOS) and band structure.
+*   **`GatherDataMPI`**: A subroutine (likely in `MPI_routines.F90`) to collect results from all MPI processes onto the root process.
+*   **`FinalizeMPI`**: A subroutine (likely in `MPI_routines.F90`) to properly shut down the MPI environment.
+*   **`DumpData`**: A subroutine (in `Dump_Data.F90`) that writes the calculated results to output files. This is typically done only by the root process.
+
+The main program coordinates calls to these routines in a specific sequence to perform the simulation. The self-consistency loop (`DO WHILE ((ite <= iteTot) .AND. (abs(AmtChange)>Accuracy))`) is a critical part where `Build_Hamiltonian` and `Calculate_OP` are called repeatedly.

--- a/NEGF_Module.md
+++ b/NEGF_Module.md
@@ -1,0 +1,127 @@
+# Documentation for NEGF_Module.F90
+
+## Overview
+
+`NEGF_Module.F90` defines a Fortran module named `NEGF_variables`. This module serves as a central repository for various global variables, physical constants, material parameters, and derived types used across different parts of the NEGF (Non-Equilibrium Green's Function) simulation code. It also contains a `Kron` function for Kronecker products. By encapsulating these definitions, it promotes code organization and avoids redundant declarations in other files.
+
+## Key Components
+
+*   **MODULE `NEGF_variables`**:
+    *   The primary component of this file. It groups all the shared data and type definitions.
+*   **FUNCTION `Kron(A, B)`**:
+    *   A utility function that calculates the Kronecker product of two complex matrices `A` and `B`.
+    *   **Input**:
+        *   `A`: A 2D complex matrix.
+        *   `B`: A 2D complex matrix.
+    *   **Output**: A 2D complex matrix representing the Kronecker product of `A` and `B`. The dimensions of the output matrix are `(size(A,1)*size(B,1), size(A,2)*size(B,2))`.
+
+## Important Variables/Constants
+
+The module declares a wide range of variables and constants. These can be broadly categorized as:
+
+### Physical Constants
+*   **`ci`**: Imaginary unit (0, 1).
+*   **`c0`**: Complex zero (0, 0).
+*   **`c1`**: Complex one (1, 0).
+*   **`q`**: Elementary charge.
+*   **`m0`**: Electron rest mass.
+*   **`pi`**: Mathematical constant pi.
+*   **`eps0`**: Vacuum permittivity.
+*   **`kB`**: Boltzmann constant.
+*   **`h`**: Planck constant.
+*   **`hbar`**: Reduced Planck constant.
+
+### Device Parameters
+*   **`MM`**: Dirac Mass, critical for defining topological phases.
+*   **`Norb`**: Number of orbitals (e.g., 4 for a 3D Dirac Hamiltonian).
+*   **`muTI`, `muSC`**: Chemical potentials for the Topological Insulator (TI) and Superconductor (SC) regions.
+*   **`UIntTI`, `UIntSC`**: Attractive Mean-Field interaction strengths for TI and SC.
+*   **`tSC`**: Hopping parameter for the s-wave superconductor.
+*   **`T0`**: Temperature (must be non-zero).
+*   **`Mx`, `My`, `Mz`**: Components of an external Zeeman field.
+*   **`Myz`**: Parameter for yz Mirror-plane breaking perturbation.
+*   **`MatType`**: Integer selecting the material model (0: Model TI, 1: Liang Fu TCI, 2: Bi2Se3).
+*   **`a0`**: Lattice constant in Angstroms.
+
+### Tight-Binding Parameters
+*   Parameters for specific models like Liang Fu (LF) TCI (e.g., `LFm`, `LFt11`) and Chen et al. (CF) TCI (e.g., `CFm`, `CFt1`).
+
+### Input Parameters
+*   **`nargs`**: Number of command-line arguments.
+*   **`arg`**: Character string to store a command-line argument.
+*   **`outputfiledir`**: Directory path for output files.
+*   **`NpKx`, `NpKy`**: Number of k-points along Kx and Ky axes.
+*   **`Npz`, `NpzSC`**: Number of layers in z-direction for the total system and the SC part.
+*   **`NN`**: Total number of grid points (`Npz * Norb`).
+
+### Iteration/Convergence Variables
+*   **`ite`, `iteTot`**: Current and total iteration counts for self-consistency loops.
+*   **`AmtChange`**: Magnitude of change between iterations (for convergence check).
+*   **`RMSChange`**: Root Mean Square change.
+*   **`Accuracy`**: Convergence criterion.
+
+### Matrices
+*   **Gamma Matrices (`g1`, `g2`, `g3`, `g0`, `id`)**: Standard Dirac gamma matrices and identity matrix.
+*   **TCI Matrices (`Sig0`, `Sig1`, etc.)**: Matrices specific to Topological Crystalline Insulator models.
+*   **Hamiltonian Component Matrices (`HLdotS`, `HSOC`, `HOnSite`, `HZeeman`, `HNN`, `HNNN`, `HHop`, etc.)**: Matrices representing different terms in the Hamiltonian.
+*   **Superconducting Pairing Matrices (`gDAS`, `gDBS`, etc.)**: Gamma matrices related to different superconducting pairing symmetries.
+*   **Order Parameter Arrays (`DeltaAS`, `DeltaBS`, `DeltaMat`, `DeltaMatOld`)**: Store the calculated order parameter values.
+*   **Hamiltonian Matrices (`Htot`, `AATI`, `HopZTI`, `eigvecs`, `eigvals`)**: Matrices for the total Hamiltonian, its components, eigenvectors, and eigenvalues.
+*   **LDOS Arrays (`LDOS`, `LDOSMx`, etc.)**: Arrays to store Local Density of States and its spin/orbital projections.
+*   **`BStruc`**: Array to store band structure information.
+
+### MPI Variables
+*   **`Nprocs`**: Total number of MPI processes.
+*   **`mpirank`, `mpisize`, `mpiroot`, `mpierror`, `mpistatus`**: Standard MPI control variables.
+
+### Momentum and Energy Parameters
+*   **`Kx`, `Ky`**: Current k-space coordinates.
+*   **`deltaKx`, `deltaKy`**: Step size in k-space.
+*   **`KxAxis`, `KyAxis`**: Arrays of k-points.
+*   **`NpE`**: Number of energy points.
+*   **`deltaE`**: Energy step size.
+*   **`Eaxis`**: Array of energy points.
+
+### Temporary/Dummy Variables
+*   **`ii`, `jj`, `kk`, `ll`, `ee`, `ctr`, `xx`, `yy`, `zz`, `index`**: Loop counters and indices.
+
+## Usage Examples
+
+### Using the Module
+Other Fortran files in the project include `USE NEGF_variables` at the beginning of their program or module units. This makes all public entities (variables, constants, types, functions) from `NEGF_variables` accessible.
+
+```fortran
+PROGRAM NEGF_main
+    USE NEGF_variables ! Makes entities from the module available
+    IMPLICIT NONE
+
+    REAL :: local_variable
+    local_variable = Kx + MM ! Kx and MM are from NEGF_variables
+
+    ! ... rest of the program
+END PROGRAM NEGF_main
+```
+
+### Using the `Kron` function
+```fortran
+USE NEGF_variables
+IMPLICIT NONE
+COMPLEX, DIMENSION(2,2) :: matrix_A, matrix_B
+COMPLEX, DIMENSION(4,4) :: result_matrix
+
+! Initialize matrix_A and matrix_B
+matrix_A(1,1) = c1; matrix_A(1,2) = c0
+matrix_A(2,1) = c0; matrix_A(2,2) = c1
+
+matrix_B(1,1) = ci; matrix_B(1,2) = c1
+matrix_B(2,1) = c1; matrix_B(2,2) = ci
+
+result_matrix = Kron(matrix_A, matrix_B)
+
+! result_matrix will now hold the Kronecker product
+```
+
+## Dependencies and Interactions
+
+*   **Provides To**: Nearly all other Fortran files in the project (`NEGF_Main.F90`, `Build_Hamiltonian.F90`, `Calculate_OP.F90`, `Read_In_Allocate.F90`, etc.) use this module to access shared variables and constants.
+*   **Dependencies**: This module itself does not have explicit dependencies on other custom modules within this project, but it relies on intrinsic Fortran capabilities. The variables it defines are populated or used by other parts of the system. For instance, `Read_In_Allocate.F90` would populate many of the input parameters, and `NEGF_Main.F90` would use iteration variables and pass various parameters to computational subroutines.


### PR DESCRIPTION
This commit introduces markdown documentation for the following key components of the NEGF simulation code:
- NEGF_Main.F90: Describes the main program flow, variables, and dependencies.
- NEGF_Module.F90: Details the shared variables, constants, and the Kron utility function.
- Build_Hamiltonian.F90: Explains how the Hamiltonian is constructed for different material models.
- Calculate_OP.F90: Covers the calculation of the order parameter and final physical quantities like LDOS and ground state energy.

Each documentation file includes sections for Overview, Key Components, Important Variables/Constants, Usage Examples (where applicable), and Dependencies/Interactions, aiming to provide clarity for developers maintaining or extending the codebase.